### PR TITLE
feat: Add export dropdown for diagram downloads

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@
 - **Toolbar actions**
   - Use "Hide diagram" / "Show diagram" toggles; ensure state persists while on the page.
   - Click "Scroll to code" and verify smooth scrolling centers the source block.
-  - Download SVG and PNG; confirm filenames are unique per block and PNG output matches expected dimensions.
+  - Open the "Export" dropdown, trigger SVG and PNG exports, and confirm filenames are unique per block while PNG output matches expected dimensions.
   - Induce a Mermaid syntax error and check that the inline error pane displays message + hint.
 - **Extension lifecycle**
   - Reload the extension in `chrome://extensions` to verify background script restores defaults without duplicates.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -9,10 +9,11 @@
 
 ## Toolbar Buttons
 
-- Order actions: `Hide diagram`, `Scroll to code`, `Download SVG`, `Download PNG`.
-- Disable download buttons until render succeeds to avoid empty files.
+- Order actions: `Hide diagram`, `Scroll to code`, `Export` dropdown.
+- Disable export actions until render succeeds to avoid empty files.
 - Provide hover feedback with subtle background changes; use consistent sizes and border radii.
 - Preserve the original label via `data-coderchart-label` so temporary text (e.g. "Preparing PNG…") can revert cleanly.
+- Close the dropdown when users click elsewhere or trigger an action so focus returns predictably.
 
 ## Options Page
 


### PR DESCRIPTION
## Summary
- replace the SVG and PNG download buttons with a single Export dropdown in the content script
- update styling helpers so the dropdown respects theme changes and disables actions when diagrams are unavailable
- refresh UI and testing docs to note the new Export workflow

## Testing
- pnpm test

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/8423055b-bf3c-454c-bfde-e990aa9c3b97" />

------
https://chatgpt.com/codex/tasks/task_b_68de2ed7f85c832ba43b83d5c60a6735

